### PR TITLE
Upload parallel checksum

### DIFF
--- a/mains/localtos3.go
+++ b/mains/localtos3.go
@@ -2,7 +2,6 @@ package mains
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/chanzuckerberg/s3parcp/checksum"
@@ -48,11 +47,7 @@ func LocalToS3(opts options.Options) {
 
 	metadata := make(map[string]*string)
 	if opts.Checksum {
-		data, err := ioutil.ReadFile(opts.Positional.Source)
-		if err != nil {
-			panic(err)
-		}
-		crc32cChecksum, err := checksum.CRC32CChecksum(data)
+		crc32cChecksum, err := checksum.ParallelCRC32CChecksum(opts.Positional.Source, opts.PartSize, opts.Concurrency, opts.MMap)
 		if err != nil {
 			os.Stderr.WriteString("Error computing crc32c checksum of source file\n")
 			panic(err)


### PR DESCRIPTION
Use the `ParallelCRC32CChecksum` for uploads. This function is faster due to parallelism and also uses less memory since it computes the checksum on chunks at a time. Not using it for uploads was an oversight.