### PR TITLE
Switch back to default http timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.0.13-alpha
+VERSION=0.0.14-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin

--- a/mains/s3tolocal.go
+++ b/mains/s3tolocal.go
@@ -2,7 +2,6 @@ package mains
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path"
 
@@ -42,14 +41,10 @@ func S3ToLocal(opts options.Options) {
 		),
 	)
 
-	httpClient := &http.Client{
-		Timeout: 15e9,
-	}
 	disableSSL := true
 	maxRetries := 3
 	client := s3.New(sess, &aws.Config{
 		DisableSSL: &disableSSL,
-		HTTPClient: httpClient,
 		MaxRetries: &maxRetries,
 	})
 


### PR DESCRIPTION
I shorted the timeout to limit some outlier cases from taking a long time to download but it seems that since I did this the download sometimes fails while with the default parameters it doesn't fail. Maybe we can tune this more in the future or make it a parameter but for now I think we should be safe.