### PR TITLE
Quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.0.15-alpha
+VERSION=0.1.0-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin

--- a/s3parcp.go
+++ b/s3parcp.go
@@ -11,9 +11,22 @@ import (
 	"github.com/chanzuckerberg/s3parcp/s3utils"
 )
 
+// Update this with new versions
+const version = "0.1.0-alpha"
+
 func main() {
 	before := time.Now()
-	opts := options.ParseArgs()
+	opts, err := options.ParseArgs()
+
+	// go-flags will handle any logging to the user, just exit on error
+	if err != nil {
+		os.Exit(2)
+	}
+
+	if opts.Version {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	sess := session.Must(session.NewSessionWithOptions(
 		session.Options{
@@ -48,11 +61,7 @@ func main() {
 		os.Exit(1)
 	}
 	if len(jobs) == 0 {
-		filesOrObjects := "files"
-		if sourcePath.IsS3() {
-			filesOrObjects = "objects"
-		}
-		message := fmt.Sprintf("no %s found at path %s\n", filesOrObjects, sourcePath)
+		message := fmt.Sprintf("no %s found at path %s\n", sourcePath.FileOrObject(), sourcePath)
 		os.Stderr.WriteString(message)
 		os.Exit(1)
 	}

--- a/s3utils/copy.go
+++ b/s3utils/copy.go
@@ -52,6 +52,11 @@ func GetCopyJobs(src Path, dest Path, recursive bool) ([]CopyJob, error) {
 		return []CopyJob{}, error
 	}
 
+	if !isSrcDir && recursive {
+		error := fmt.Errorf("source %s is not a %s but recursive was specified", src, src.DirOrFolder())
+		return []CopyJob{}, error
+	}
+
 	if !isDestDir && isSrcDir {
 		if !destExists {
 			// If the destination doesn't exist and the source is a directory

--- a/s3utils/localpath.go
+++ b/s3utils/localpath.go
@@ -16,6 +16,12 @@ type localPath struct {
 
 // IsDir Checks if a localPath is a directory
 func (p localPath) IsDir() (bool, error) {
+	// Paths with a trailing slash must be directories because creating
+	//   a file with a trailing slash doesn't work
+	if p.raw[len(p.raw)-1] != '/' {
+		return true, nil
+	}
+
 	stat, err := os.Stat(p.raw)
 	if err != nil {
 		return false, err

--- a/s3utils/s3path.go
+++ b/s3utils/s3path.go
@@ -22,6 +22,12 @@ func (p s3Path) IsDir() (bool, error) {
 		return true, nil
 	}
 
+	// Paths with a trailing slash must be directories because creating
+	//   an object with a trailing slash doesn't work
+	if p.raw[len(p.raw)-1] != '/' {
+		return true, nil
+	}
+
 	// Add trailing / to the prefix to avoid partial matches
 	prefix := addTrailingSlash(p.prefix)
 


### PR DESCRIPTION
Some improvements:
- Refuses to upload single files with `--recursive`
- Considers paths ending in `/` directories/folders which has a few advantages:
  - Skips an s3 folder check before uploading
  - Copying a single file to a non-existent path ending in a `/` would cause an issue because that path would be assumed to be a path to a single file. Now this issue is avoided
- Adds a simple version string printing
- Fixes issue where help text would print twice
- Shifts option parsing error handling into the main method