### PR TITLE
Add support for custom s3 api URLs for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.1.2-alpha
+VERSION=0.1.3-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin

--- a/options/options.go
+++ b/options/options.go
@@ -20,7 +20,7 @@ type Options struct {
 	Mmap        bool   `short:"m" long:"mmap" description:"Use mmap for downloads"`
 	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
 	Version     bool   `short:"v" long:"version" description:"Print the current version"`
-	S3Url       string `long:"s3_url" description:"A custom s3 API url, also available as an environment variable 'S3PARCP_S3_URL'"`
+	S3Url       string `long:"s3_url" description:"A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)"`
 	Positional  struct {
 		Source      string `description:"Source to copy from"`
 		Destination string `description:"Destination to copy to (Optional, defaults to source's base name)"`

--- a/options/options.go
+++ b/options/options.go
@@ -12,14 +12,15 @@ import (
 
 // Options - the options passed to the executable
 type Options struct {
-	PartSize    int64 `short:"p" long:"part-size" description:"Part size in bytes of parts to be downloaded"`
-	Concurrency int   `short:"c" long:"concurrency" description:"Download concurrency"`
-	BufferSize  int   `short:"b" long:"buffer-size" description:"Size of download buffer in bytes"`
-	Checksum    bool  `long:"checksum" description:"Compare checksum if downloading or place checksum in metadata if uploading"`
-	Duration    bool  `short:"d" long:"duration" description:"Prints the duration of the download"`
-	Mmap        bool  `short:"m" long:"mmap" description:"Use mmap for downloads"`
-	Recursive   bool  `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
-	Version     bool  `short:"v" long:"version" description:"Print the current version"`
+	PartSize    int64  `short:"p" long:"part-size" description:"Part size in bytes of parts to be downloaded"`
+	Concurrency int    `short:"c" long:"concurrency" description:"Download concurrency"`
+	BufferSize  int    `short:"b" long:"buffer-size" description:"Size of download buffer in bytes"`
+	Checksum    bool   `long:"checksum" description:"Compare checksum if downloading or place checksum in metadata if uploading"`
+	Duration    bool   `short:"d" long:"duration" description:"Prints the duration of the download"`
+	Mmap        bool   `short:"m" long:"mmap" description:"Use mmap for downloads"`
+	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
+	Version     bool   `short:"v" long:"version" description:"Print the current version"`
+	S3Url       string `long:"s3_url" description:"A custom s3 API url, also available as an environment variable 'S3PARCP_S3_URL'"`
 	Positional  struct {
 		Source      string `description:"Source to copy from"`
 		Destination string `description:"Destination to copy to (Optional, defaults to source's base name)"`
@@ -50,6 +51,13 @@ func ParseArgs() (Options, error) {
 
 	if opts.Concurrency == 0 {
 		opts.Concurrency = runtime.NumCPU()
+	}
+
+	if opts.S3Url == "" {
+		envS3Url := os.Getenv("S3PARCP_S3_URL")
+		if envS3Url != "" {
+			opts.S3Url = envS3Url
+		}
 	}
 
 	return opts, nil

--- a/s3utils/copy.go
+++ b/s3utils/copy.go
@@ -116,14 +116,7 @@ type Copier struct {
 }
 
 // NewCopier creates a new Copier
-func NewCopier(opts CopierOptions) Copier {
-	sess := session.Must(
-		session.NewSessionWithOptions(
-			session.Options{
-				SharedConfigState: session.SharedConfigEnable,
-			},
-		),
-	)
+func NewCopier(opts CopierOptions, sess *session.Session) Copier {
 
 	// TODO make configurable
 	disableSSL := true


### PR DESCRIPTION
For testing we want the ability to use a mock s3 using moto. I added support for a custom s3 API URL so we can point it to the mock s3 for testing purposes. 

Normally I add options as flags but I felt it would make testing much easier to have this option as an environment variable. This way the variable can be set globally and we don't need to add conditionals for test cases in the code itself. I namespaced the environment variable with `S3PARCP_` to prevent conflicts. I also made it available as a flag, mostly just to document it.

I tested both cases with the actual s3 API URL.