### PR TITLE
Fix an issue with missing expiry on environment credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.1.5-alpha
+VERSION=0.1.6-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin

--- a/s3parcp.go
+++ b/s3parcp.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Update this with new versions
-const version = "0.1.5-alpha"
+const version = "0.1.6-alpha"
 
 func main() {
 	before := time.Now()


### PR DESCRIPTION
Don't cache credentials if we don't get an expiry.