### PR TITLE
More Conservative Defaults and Debugging Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.1.6-alpha
+VERSION=0.1.7-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unfortunately, Windows is not yet supported.
 ```bash
 # Update based on your platform
 PLATFORM=#Darwin_i386/Darwin_x86_64/Linux_i386/Linux_x86_64
-VERSION=0.1.7-alpha
+VERSION=0.2.0-alpha
 RELEASES=https://github.com/chanzuckerberg/s3parcp/releases/download
 curl -L $RELEASES/v$VERSION/s3parcp_"$VERSION"_$PLATFORM.tar.gz | tar zx
 mv s3parcp ~/.local/bin
@@ -31,8 +31,11 @@ Application Options:
   -d, --duration     Prints the duration of the download
   -m, --mmap         Use mmap for downloads
   -r, --recursive    Copy directories or folders recursively
-  -v, --version      Print the current version
+      --version      Print the current version
       --s3_url=      A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)
+      --max-retries= Max per chunk retries
+      --disable-ssl  Disable SSL
+  -v, --verbose      verbose logging
 
 Help Options:
   -h, --help         Show this help message

--- a/options/options.go
+++ b/options/options.go
@@ -53,6 +53,9 @@ func ParseArgs() (Options, error) {
 
 	if opts.Concurrency == 0 {
 		opts.Concurrency = runtime.NumCPU() / 2
+		if opts.Concurrency < 1 {
+			opts.Concurrency = 1
+		}
 	}
 
 	if opts.MaxRetries == 0 {

--- a/options/options.go
+++ b/options/options.go
@@ -21,7 +21,7 @@ type Options struct {
 	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
 	Version     bool   `long:"version" description:"Print the current version"`
 	S3Url       string `long:"s3_url" description:"A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)"`
-	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries"`
+	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries" default:"6"`
 	DisableSSL  bool   `long:"disable-ssl" description:"Disable SSL"`
 	Verbose     bool   `short:"v" long:"verbose" description:"verbose logging"`
 	Positional  struct {
@@ -57,10 +57,6 @@ func ParseArgs() (Options, error) {
 		if opts.Concurrency < 1 {
 			opts.Concurrency = 1
 		}
-	}
-
-	if opts.MaxRetries == 0 {
-		opts.MaxRetries = 6
 	}
 
 	if opts.S3Url == "" {

--- a/options/options.go
+++ b/options/options.go
@@ -19,10 +19,11 @@ type Options struct {
 	Duration    bool   `short:"d" long:"duration" description:"Prints the duration of the download"`
 	Mmap        bool   `short:"m" long:"mmap" description:"Use mmap for downloads"`
 	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
-	Version     bool   `short:"v" long:"version" description:"Print the current version"`
+	Version     bool   `long:"version" description:"Print the current version"`
 	S3Url       string `long:"s3_url" description:"A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)"`
 	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries"`
 	DisableSSL  bool   `long:"disable-ssl" description:"Disable SSL"`
+	Verbose     bool   `short:"v" long:"verbose" description:"verbose logging"`
 	Positional  struct {
 		Source      string `description:"Source to copy from"`
 		Destination string `description:"Destination to copy to (Optional, defaults to source's base name)"`

--- a/options/options.go
+++ b/options/options.go
@@ -21,6 +21,8 @@ type Options struct {
 	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
 	Version     bool   `short:"v" long:"version" description:"Print the current version"`
 	S3Url       string `long:"s3_url" description:"A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)"`
+	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries"`
+	DisableSSL  bool   `long:"disable-ssl" description:"Disable SSL"`
 	Positional  struct {
 		Source      string `description:"Source to copy from"`
 		Destination string `description:"Destination to copy to (Optional, defaults to source's base name)"`
@@ -50,7 +52,11 @@ func ParseArgs() (Options, error) {
 	}
 
 	if opts.Concurrency == 0 {
-		opts.Concurrency = runtime.NumCPU()
+		opts.Concurrency = runtime.NumCPU() / 2
+	}
+
+	if opts.MaxRetries == 0 {
+		opts.MaxRetries = 6
 	}
 
 	if opts.S3Url == "" {

--- a/options/options.go
+++ b/options/options.go
@@ -21,7 +21,7 @@ type Options struct {
 	Recursive   bool   `short:"r" long:"recursive" description:"Copy directories or folders recursively"`
 	Version     bool   `long:"version" description:"Print the current version"`
 	S3Url       string `long:"s3_url" description:"A custom s3 API url (also available as an environment variable 'S3PARCP_S3_URL', the flag takes precedence)"`
-	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries" default:"6"`
+	MaxRetries  int    `long:"max-retries" description:"Max per chunk retries" default:"3"`
 	DisableSSL  bool   `long:"disable-ssl" description:"Disable SSL"`
 	Verbose     bool   `short:"v" long:"verbose" description:"verbose logging"`
 	Positional  struct {
@@ -53,10 +53,7 @@ func ParseArgs() (Options, error) {
 	}
 
 	if opts.Concurrency == 0 {
-		opts.Concurrency = runtime.NumCPU() / 2
-		if opts.Concurrency < 1 {
-			opts.Concurrency = 1
-		}
+		opts.Concurrency = runtime.NumCPU()
 	}
 
 	if opts.S3Url == "" {

--- a/s3parcp.go
+++ b/s3parcp.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Update this with new versions
-const version = "0.1.7-alpha"
+const version = "0.2.0-alpha"
 
 func main() {
 	before := time.Now()

--- a/s3parcp.go
+++ b/s3parcp.go
@@ -81,8 +81,10 @@ func main() {
 		Checksum:    opts.Checksum,
 		Concurrency: opts.Concurrency,
 		Mmap:        opts.Mmap,
+		DisableSSL:  opts.DisableSSL,
 		MaxRetries:  opts.MaxRetries,
 		PartSize:    opts.PartSize,
+		Verbose:     opts.Verbose,
 	}
 	copier := s3utils.NewCopier(copierOpts, sess)
 	jobs, err := s3utils.GetCopyJobs(sourcePath, destPath, opts.Recursive)

--- a/s3parcp.go
+++ b/s3parcp.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Update this with new versions
-const version = "0.1.6-alpha"
+const version = "0.1.7-alpha"
 
 func main() {
 	before := time.Now()
@@ -81,6 +81,7 @@ func main() {
 		Checksum:    opts.Checksum,
 		Concurrency: opts.Concurrency,
 		Mmap:        opts.Mmap,
+		MaxRetries:  opts.MaxRetries,
 		PartSize:    opts.PartSize,
 	}
 	copier := s3utils.NewCopier(copierOpts, sess)

--- a/s3utils/copy.go
+++ b/s3utils/copy.go
@@ -103,9 +103,11 @@ type CopierOptions struct {
 	BufferSize  int
 	Checksum    bool
 	Concurrency int
+	DisableSSL  bool
 	Mmap        bool
 	MaxRetries  int
 	PartSize    int64
+	Verbose     bool
 }
 
 // Copier holds state for copying
@@ -119,14 +121,18 @@ type Copier struct {
 // NewCopier creates a new Copier
 func NewCopier(opts CopierOptions, sess *session.Session) Copier {
 
-	// TODO make configurable
-	disableSSL := true
-	logLevel := aws.LogDebugWithRequestRetries
-	client := s3.New(sess, &aws.Config{
-		DisableSSL: &disableSSL,
+	debugLogLevel := aws.LogDebugWithRequestRetries
+
+	config := aws.Config{
+		DisableSSL: &opts.DisableSSL,
 		MaxRetries: &opts.MaxRetries,
-		LogLevel:   &logLevel,
-	})
+	}
+
+	if opts.Verbose {
+		config.LogLevel = &debugLogLevel
+	}
+
+	client := s3.New(sess, &config)
 
 	downloader := s3manager.NewDownloader(sess, func(d *s3manager.Downloader) {
 		d.PartSize = opts.PartSize

--- a/s3utils/copy.go
+++ b/s3utils/copy.go
@@ -104,6 +104,7 @@ type CopierOptions struct {
 	Checksum    bool
 	Concurrency int
 	Mmap        bool
+	MaxRetries  int
 	PartSize    int64
 }
 
@@ -120,10 +121,11 @@ func NewCopier(opts CopierOptions, sess *session.Session) Copier {
 
 	// TODO make configurable
 	disableSSL := true
-	maxRetries := 3
+	logLevel := aws.LogDebugWithRequestRetries
 	client := s3.New(sess, &aws.Config{
 		DisableSSL: &disableSSL,
-		MaxRetries: &maxRetries,
+		MaxRetries: &opts.MaxRetries,
+		LogLevel:   &logLevel,
 	})
 
 	downloader := s3manager.NewDownloader(sess, func(d *s3manager.Downloader) {


### PR DESCRIPTION
This PR:
- Makes per-chunk retry configurable.
- Makes disabling ssl configurable and defaults to enabled (disable: false)
- Add a verbose logging option that prints debug logs from the s3 API. This will be turned on so we can identify where the failure is coming from specifically.