### PR TITLE
fix bug with uploading to a subdirectory

### DIFF
--- a/s3parcp.go
+++ b/s3parcp.go
@@ -55,9 +55,6 @@ func main() {
 		})
 
 		configFuncs = append(configFuncs, config.WithEndpointResolverWithOptions(customDomainResolver))
-		if err != nil {
-			log.Fatal(err)
-		}
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), configFuncs...)

--- a/s3utils/copy.go
+++ b/s3utils/copy.go
@@ -246,7 +246,7 @@ func (c *Copier) localCopy(src string, dest string) error {
 // Copy executes a copy job
 func (c *Copier) Copy(copyJob CopyJob) error {
 	if copyJob.source.IsS3() && copyJob.destination.IsS3() {
-		return errors.New("Copying between s3 is not yet supported")
+		return errors.New("copying between s3 is not yet supported")
 	} else if !copyJob.source.IsS3() && copyJob.destination.IsS3() {
 		bucket, err := copyJob.destination.Bucket()
 		if err != nil {

--- a/s3utils/s3path.go
+++ b/s3utils/s3path.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"path"
 
+	"github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 type s3Path struct {
@@ -64,8 +64,8 @@ func (p s3Path) Exists() (bool, error) {
 		Key:    &p.prefix,
 	})
 
-	var notFound *types.NotFound
-	if err != nil && errors.As(err, &notFound) {
+	var notFound *http.ResponseError
+	if err != nil && errors.As(err, &notFound) && notFound.HTTPStatusCode() == 404 {
 		return false, nil
 	}
 


### PR DESCRIPTION
When uploading to something other than a top level bucket s3parcp would break because my error recognition wasn't working.